### PR TITLE
perf: use cheaply invertible conditional in require

### DIFF
--- a/src/yulplus.ne
+++ b/src/yulplus.ne
@@ -292,7 +292,7 @@ function mslice(position, length) -> result {
 
   const requireMethod = `
 function require(arg, message) {
-  if lt(arg, 1) {
+  if iszero(eq(arg, 1)) {
     mstore(0, message)
     revert(0, 32)
   }


### PR DESCRIPTION
due to the nature of how `JUMPI` is used by the compiler (it jumps OVER an if, not into it) , the compiler often has to invert if statement conditionals by wrapping them in an `iszero()`. using expression already wrapped in an `iszero()` allows the compiler to simply remove the `iszero()` and avoid adding any additional uses, as removing the `iszero()` *is* the inversion.