### PR TITLE
perf: even simpler require()

### DIFF
--- a/src/yulplus.ne
+++ b/src/yulplus.ne
@@ -288,7 +288,7 @@ function mslice(position, length) -> result {
 
   const requireMethod = `
 function require(arg, message) {
-  if iszero(eq(arg, 1)) {
+  if iszero(arg) {
     mstore(0, message)
     revert(0, 32)
   }


### PR DESCRIPTION
is there a need to enforce the arg is 1 or can we just check if it's 0? if you're ok with any non-zero value being true, then you can remove the eq()

this is done in the Solidity doc's Yul example, which is why i reconsidered it 

<img width="362" alt="Screen Shot 2021-12-27 at 12 36 24 PM" src="https://user-images.githubusercontent.com/26209401/147505619-83f57555-3e2b-4e14-a841-12ba69dd699e.png">
 